### PR TITLE
Fix/deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jenkins:2.63-alpine
+FROM jenkinsci/jenkins
 
 MAINTAINER Basilio Vera <basilio.vera@softonic.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jenkins
+FROM jenkins/jenkins
 
 MAINTAINER Basilio Vera <basilio.vera@softonic.com>
 


### PR DESCRIPTION
In order to keep using the non deprecated jenkins. We changed the Dockerfile to use the new repository instead the deprecated one's 
DEPRECATED: -> https://hub.docker.com/r/jenkinsci/jenkins/
New ones: -> https://hub.docker.com/r/jenkins/jenkins/